### PR TITLE
Automated REST API paths generating

### DIFF
--- a/define/channel.rest.js
+++ b/define/channel.rest.js
@@ -13,10 +13,9 @@ ConfigManager.set_default_config(
     }
 );
 
-var rest_url_base = ConfigManager.get_config().rest_config.url_base;
-
 REST.start = function(){
     var resource_types = Sealious.ChipManager.get_all_resource_types();
+    var rest_url_base = ConfigManager.get_config().rest_config.url_base;
     for (var i in resource_types) {
         var complete_url = rest_url_base + '/' + resource_types[i];
         REST.add_path(complete_url, resource_types[i]);

--- a/define/channel.rest.js
+++ b/define/channel.rest.js
@@ -11,16 +11,11 @@ REST.default_configuration = {
 }
 
 REST.start = function(){
-    REST.set_url_base(REST.configuration.url_base);
-}
-
-REST.set_url_base = function(base_url) {
     var resource_types = Sealious.ChipManager.get_all_resource_types();
     for (var i in resource_types) {
-        var complete_url = base_url + '/' + resource_types[i];
+        var complete_url = REST.configuration.url_base + '/' + resource_types[i];
         REST.add_path(complete_url, resource_types[i]);
     }
-
 }
 
 REST.add_path = function(url, resource_type_name){

--- a/define/channel.rest.js
+++ b/define/channel.rest.js
@@ -6,6 +6,14 @@ var get_context = www_server.get_context;
 
 var REST = new Sealious.ChipTypes.Channel("rest");
 
+REST.default_configuration = {
+    url_base: "/api/v1"
+}
+
+REST.start = function(){
+    REST.set_url_base(REST.configuration.url_base);
+}
+
 REST.set_url_base = function(base_url) {
     var resource_types = Sealious.ChipManager.get_all_resource_types();
     for (var i in resource_types) {

--- a/define/channel.rest.js
+++ b/define/channel.rest.js
@@ -1,19 +1,24 @@
 require("sealious-www-server");
 var Sealious = require("sealious");
 var www_server = Sealious.ChipManager.get_chip("channel", "www_server");
+var ConfigManager = Sealious.ConfigManager;
 
 var get_context = www_server.get_context;
 
 var REST = new Sealious.ChipTypes.Channel("rest");
 
-REST.default_configuration = {
-    url_base: "/api/v1"
-}
+ConfigManager.set_default_config( 
+    "rest_config", {
+        url_base: "/api/v1"
+    }
+);
+
+var rest_url_base = ConfigManager.get_config().rest_config.url_base;
 
 REST.start = function(){
     var resource_types = Sealious.ChipManager.get_all_resource_types();
     for (var i in resource_types) {
-        var complete_url = REST.configuration.url_base + '/' + resource_types[i];
+        var complete_url = rest_url_base + '/' + resource_types[i];
         REST.add_path(complete_url, resource_types[i]);
     }
 }


### PR DESCRIPTION
https://github.com/Sealious/sealious-channel-rest/issues/6

I added 'start' method and default configuration for rest chip. Now paths are generated on starting chips, so user doesn't have to set their base URL in index.js/main.js .
